### PR TITLE
fix: update coverage command in Makefile and add .nyc_output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 /.vscode
 .env
+.nyc_output

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,7 @@ lint:
 	npx eslint src
 	npm run dtslint-next
 coverage:
-	node_modules/istanbul/lib/cli.js cover \
-		-i 'src/*' \
-		--include-all-sources \
-		--dir coverage \
-		node_modules/jasme/run.js
+	npx nyc --include src --reporter=lcov --reporter=text node_modules/jasme/run.js
 
 coveralls: coverage
-ifndef COVERALLS_REPO_TOKEN
-	$(error COVERALLS_REPO_TOKEN is undefined)
-endif
-	node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
+	npx nyc report --reporter=text-lcov | npx coveralls


### PR DESCRIPTION
This pull request updates the code coverage and reporting tools in the `Makefile` to use more modern and streamlined commands. The main improvements are the replacement of deprecated or manual tool invocations with `npx`-based equivalents, simplifying the process and improving compatibility.

**Coverage tooling updates:**

* Replaced manual `istanbul` invocation in the `coverage` target with `npx nyc`, and updated the command to generate both `lcov` and text reports. (`Makefile`)
* Simplified the `coveralls` target by removing the need for the `COVERALLS_REPO_TOKEN` environment check and using `npx nyc report` piped directly to `npx coveralls`. (`Makefile`)