### PR TITLE
fix: replace npm install with npm ci and add provenance flag to npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: npm publish --access public
+      - run: npm ci
+      - run: npm publish --provenance --access public
 
   release:
     needs: publish


### PR DESCRIPTION
This pull request updates the npm publish workflow to improve reliability and security during releases. The most important changes are:

Workflow improvements:

* Replaced `npm install` with `npm ci` to ensure a clean and reproducible install of dependencies in the release workflow (`.github/workflows/release.yml`).
* Added the `--provenance` flag to `npm publish` to provide verifiable build provenance for published packages, enhancing supply chain security (`.github/workflows/release.yml`).